### PR TITLE
Fix protoc-gen-go url

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ brew install protobuf protoc-gen-go protoc-gen-go-grpc
 alternatively you can install the protoc plugins using golang
 
 ```
-$ go install google.golang.org/grpc/cmd/protoc-gen-go@v1.1
+$ go install google.golang.org/grpc/cmd/protoc-gen-go@v1.26
 $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
 ```
 
@@ -37,7 +37,7 @@ $ yay -S protoc-gen-go protoc-gen-go-grpc
 Using golang
 
 ```
-$ go install google.golang.org/grpc/cmd/protoc-gen-go@v1.1
+$ go install google.golang.org/grpc/cmd/protoc-gen-go@v1.26
 $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ brew install protobuf protoc-gen-go protoc-gen-go-grpc
 alternatively you can install the protoc plugins using golang
 
 ```
-$ go install google.golang.org/grpc/cmd/protoc-gen-go@v1.26
+$ go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
 $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
 ```
 
@@ -37,7 +37,7 @@ $ yay -S protoc-gen-go protoc-gen-go-grpc
 Using golang
 
 ```
-$ go install google.golang.org/grpc/cmd/protoc-gen-go@v1.26
+$ go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.26
 $ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1
 ```
 


### PR DESCRIPTION
The go install command for protoc-gen-go is incorrect.
I fixed it according to your video.

![image](https://github.com/dreamsofcode-io/grpc/assets/84747244/9c4f3907-d4f4-4636-b86d-9e4036f2e353)
